### PR TITLE
Added support for multilingual websites

### DIFF
--- a/AuditLog/resources/stubs/create_audit_log_table.php.stub
+++ b/AuditLog/resources/stubs/create_audit_log_table.php.stub
@@ -16,6 +16,7 @@ class CreateAuditLogTable extends Migration
             $table->increments('id');
             $table->string('user_id');
             $table->string('data_id')->nullable();
+            $table->string('locale')->nullable();
             $table->string('event')->nullable();
             $table->text('meta')->nullable();
             $table->text('snapshot')->nullable();

--- a/AuditLog/resources/views/index.blade.php
+++ b/AuditLog/resources/views/index.blade.php
@@ -15,6 +15,7 @@
         <thead>
           <tr>
             <th>Title</th>
+            <th>Locale</th>
             <th>Event</th>
             <th>User</th>
             <th>Date</th>
@@ -28,6 +29,9 @@
               <a href="{{ route('auditlog.show', $event) }}">
                 {{ $event->getTitle() }}
               </a>
+            </td>
+            <td>
+              {{ $event->locale }}
             </td>
             <td>
               {{ $event->event }}

--- a/AuditLog/resources/views/show.blade.php
+++ b/AuditLog/resources/views/show.blade.php
@@ -20,6 +20,11 @@
     </p>
 
     <p>
+      <strong>Locale:</strong>
+      {{ $event->locale }}
+    </p>
+
+    <p>
       <strong>Event:</strong>
       {{ $event->event }}
     </p>


### PR DESCRIPTION
Hi there @aryehraber ,

The addon doesn't tell in what locale data has been changed. Because one of our clients did require this I have made this little PR.

I have added an extra `locale` column to the database migration. When saving a Page, Term, Entry or Global it will save the locale (shorthand) that has been edited.
It also saves the localised data in the snapshot instead of the default locale's data.

The overview and detail page in the CP show the locale's name.

![image](https://user-images.githubusercontent.com/3294611/58472660-06e76580-8147-11e9-8458-18dc13d92441.png)

![image](https://user-images.githubusercontent.com/3294611/58472693-1bc3f900-8147-11e9-98ae-92d62e0d1b97.png)

Hope you like it.

Gr, Gydo